### PR TITLE
Open Telemetry Compatibility

### DIFF
--- a/Pilgaard.CronJobs.sln
+++ b/Pilgaard.CronJobs.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pilgaard.CronJobs.Examples.OpenTelemetry", "samples\Pilgaard.CronJobs.Examples.OpenTelemetry\Pilgaard.CronJobs.Examples.OpenTelemetry.csproj", "{6A2D35C0-DBF9-4467-900C-724313E3B15E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{C3724948-F508-4617-8EC1-38163FF38985}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3724948-F508-4617-8EC1-38163FF38985}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3724948-F508-4617-8EC1-38163FF38985}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A2D35C0-DBF9-4467-900C-724313E3B15E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A2D35C0-DBF9-4467-900C-724313E3B15E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A2D35C0-DBF9-4467-900C-724313E3B15E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A2D35C0-DBF9-4467-900C-724313E3B15E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,6 +71,7 @@ Global
 		{7FB4DF28-49C9-4347-8CCC-0D0539649ADE} = {AFBF3DFF-2BC5-47C9-A5B7-6CC93609FC4E}
 		{8B798DE2-EF3C-4471-BA85-2AA4D1DC9AE9} = {F80C4EC1-D73B-4602-9B01-BD98ECDE3905}
 		{C3724948-F508-4617-8EC1-38163FF38985} = {FBC5473F-AA1B-4DF8-9AD9-64B6705797FF}
+		{6A2D35C0-DBF9-4467-900C-724313E3B15E} = {F80C4EC1-D73B-4602-9B01-BD98ECDE3905}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AE30DB9E-1DB2-4346-9C9E-A487459AA94B}

--- a/samples/Pilgaard.CronJobs.Examples.MinimalAPI/CronJob.cs
+++ b/samples/Pilgaard.CronJobs.Examples.MinimalAPI/CronJob.cs
@@ -1,13 +1,13 @@
-﻿using Cronos;
+using Cronos;
 
 namespace Pilgaard.CronJobs.Examples.MinimalAPI;
 
-public class ApiCallerCronJob : ICronJob
+public class CronJob : ICronJob
 {
-    private readonly ILogger<ApiCallerCronJob> _logger;
-    private static readonly HttpClient Client = new();
+    private readonly ILogger<CronJob> _logger;
+    private static readonly HttpClient _client = new();
 
-    public ApiCallerCronJob(ILogger<ApiCallerCronJob> logger)
+    public CronJob(ILogger<CronJob> logger)
     {
         _logger = logger;
     }
@@ -15,12 +15,12 @@ public class ApiCallerCronJob : ICronJob
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Executing CronJob {nameofApiCallerCronJob} at {timeNow}",
-            nameof(ApiCallerCronJob),
+            nameof(CronJob),
             DateTime.UtcNow.ToString("T"));
 
         const string endpoint = "https://localhost:7021/weatherforecast";
 
-        await Client.GetAsync(endpoint, cancellationToken);
+        await _client.GetAsync(endpoint, cancellationToken);
     }
 
     /// <summary>

--- a/samples/Pilgaard.CronJobs.Examples.MinimalAPI/Program.cs
+++ b/samples/Pilgaard.CronJobs.Examples.MinimalAPI/Program.cs
@@ -10,6 +10,6 @@ var app = builder.Build();
 
 app.UseHttpsRedirection();
 
-app.MapGet("/weatherforecast", WeatherForecasterEndpoint.Get);
+app.MapGet("/weatherforecast", WeatherForecastEndpoint.Get);
 
 app.Run();

--- a/samples/Pilgaard.CronJobs.Examples.MinimalAPI/WeatherForecastEndpoint.cs
+++ b/samples/Pilgaard.CronJobs.Examples.MinimalAPI/WeatherForecastEndpoint.cs
@@ -1,23 +1,23 @@
 namespace Pilgaard.CronJobs.Examples.MinimalAPI;
 
-public class WeatherForecasterEndpoint
+public class WeatherForecastEndpoint
 {
-    public static IEnumerable<WeatherForecast> Get(ILogger<WeatherForecasterEndpoint> logger)
+    public static IEnumerable<WeatherForecast> Get(ILogger<WeatherForecastEndpoint> logger)
     {
         logger.LogInformation("Received request at {timeNow}", DateTime.UtcNow.ToString("T"));
 
-        foreach (var index in Enumerable.Range(1, 5))
+        foreach (int index in Enumerable.Range(1, 5))
         {
             yield return new WeatherForecast
             (
                 DateTime.Now.AddDays(index),
                 Random.Shared.Next(-20, 55),
-                Summaries[Random.Shared.Next(Summaries.Length)]
+                _summaries[Random.Shared.Next(_summaries.Length)]
             );
         }
     }
 
-    private static readonly string[] Summaries = new[]
+    private static readonly string[] _summaries = new[]
     {
         "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
     };

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/CronJob.cs
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/CronJob.cs
@@ -1,0 +1,30 @@
+using Cronos;
+
+namespace Pilgaard.CronJobs.Examples.OpenTelemetry;
+
+public class CronJob : ICronJob
+{
+    private readonly ILogger<CronJob> _logger;
+    private static readonly HttpClient _client = new();
+
+    public CronJob(ILogger<CronJob> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Executing CronJob {nameofApiCallerCronJob} at {timeNow}",
+            nameof(CronJob),
+            DateTime.UtcNow.ToString("T"));
+
+        const string endpoint = "https://localhost:7243/weatherforecast";
+
+        await _client.GetAsync(endpoint, cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes once every second
+    /// </summary>
+    public CronExpression CronSchedule => CronExpression.Parse("* * * * * *", CronFormat.IncludeSeconds);
+}

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/Pilgaard.CronJobs.Examples.OpenTelemetry.csproj
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/Pilgaard.CronJobs.Examples.OpenTelemetry.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetVersion)</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Pilgaard.CronJobs\Pilgaard.CronJobs.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/Properties/launchSettings.json
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Pilgaard.CronJobs.Examples.OpenTelemetry": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:7243;http://localhost:5133",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/SlowCronJob.cs
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/SlowCronJob.cs
@@ -1,0 +1,27 @@
+using Cronos;
+
+namespace Pilgaard.CronJobs.Examples.OpenTelemetry;
+
+public class SlowCronJob : ICronJob
+{
+    private readonly ILogger<SlowCronJob> _logger;
+
+    public SlowCronJob(ILogger<SlowCronJob> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Executing CronJob {nameofApiCallerCronJob} at {timeNow}",
+            nameof(SlowCronJob),
+            DateTime.UtcNow.ToString("T"));
+
+        await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes once every second
+    /// </summary>
+    public CronExpression CronSchedule => CronExpression.Parse("* * * * * *", CronFormat.IncludeSeconds);
+}

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/WeatherForecastEndpoint.cs
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/WeatherForecastEndpoint.cs
@@ -1,0 +1,29 @@
+namespace Pilgaard.CronJobs.Examples.OpenTelemetry;
+
+public class WeatherForecastEndpoint
+{
+    public static IEnumerable<WeatherForecast> Get(ILogger<WeatherForecastEndpoint> logger)
+    {
+        logger.LogInformation("Received request at {timeNow}", DateTime.UtcNow.ToString("T"));
+
+        foreach (int index in Enumerable.Range(1, 5))
+        {
+            yield return new WeatherForecast
+            (
+                DateTime.Now.AddDays(index),
+                Random.Shared.Next(-20, 55),
+                _summaries[Random.Shared.Next(_summaries.Length)]
+            );
+        }
+    }
+
+    private static readonly string[] _summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    public record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
+    {
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    }
+}

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/appsettings.Development.json
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/appsettings.json
+++ b/samples/Pilgaard.CronJobs.Examples.OpenTelemetry/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Pilgaard.CronJobs/CronBackgroundService.cs
+++ b/src/Pilgaard.CronJobs/CronBackgroundService.cs
@@ -95,7 +95,10 @@ public class CronBackgroundService : BackgroundService
         await Task.Delay(delay, stoppingToken);
 
         // Measure duration of ExecuteAsync
-        using var timer = _histogram.NewTimer();
+        using var timer = _histogram.NewTimer(tags:
+            new[]{
+                new KeyValuePair<string, object?>("job_name", _cronJobName)
+            });
 
         // If ServiceLifetime is Transient or Scoped, we need to re-fetch the
         // CronJob from the ServiceProvider on every execution.

--- a/src/Pilgaard.CronJobs/Extensions/HistogramExtensions.cs
+++ b/src/Pilgaard.CronJobs/Extensions/HistogramExtensions.cs
@@ -12,5 +12,5 @@ public static class HistogramExtensions
     /// Dispose of the returned instance to report the elapsed duration.
     /// </para>
     /// </summary>
-    public static ITimer NewTimer(this Histogram<double> histogram) => new Timer(histogram);
+    public static ITimer NewTimer(this Histogram<double> histogram, params KeyValuePair<string, object?>[] tags) => new Timer(histogram, tags);
 }

--- a/src/Pilgaard.CronJobs/Extensions/HistogramExtensions.cs
+++ b/src/Pilgaard.CronJobs/Extensions/HistogramExtensions.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.Metrics;
+using Pilgaard.CronJobs.Telemetry;
+using Timer = Pilgaard.CronJobs.Telemetry.Timer;
+
+namespace Pilgaard.CronJobs.Extensions;
+
+public static class HistogramExtensions
+{
+    /// <summary>
+    /// Enables you to easily report elapsed seconds in the value of a <see cref="Histogram{T}"/>.
+    /// <para>
+    /// Dispose of the returned instance to report the elapsed duration.
+    /// </para>
+    /// </summary>
+    public static ITimer NewTimer(this Histogram<double> histogram) => new Timer(histogram);
+}

--- a/src/Pilgaard.CronJobs/Pilgaard.CronJobs.csproj
+++ b/src/Pilgaard.CronJobs/Pilgaard.CronJobs.csproj
@@ -26,22 +26,23 @@
 		<None Include="..\..\assets\logo\logo_128x128.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Cronos" Version="0.7.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
+  </ItemGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)' == '$(NetVersion)'">
-		<PackageReference Include="Cronos" Version="0.7.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">
-		<PackageReference Include="Cronos" Version="0.7.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.18" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
-	</ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Pilgaard.CronJobs/Telemetry/Timer.cs
+++ b/src/Pilgaard.CronJobs/Telemetry/Timer.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.Metrics;
+
+namespace Pilgaard.CronJobs.Telemetry;
+
+// Copied from https://github.com/prometheus-net/prometheus-net/blob/7eec46bbe81f5eb425e1ab9e544a9137672996df/Prometheus/TimerExtensions.cs
+internal sealed class Timer : ITimer
+{
+    private readonly ValueStopwatch _stopwatch = ValueStopwatch.StartNew();
+    private readonly Action<double> _observeDurationAction;
+    internal Timer(Histogram<double> histogram)
+    {
+        _observeDurationAction = histogram.Record;
+    }
+
+    public void Dispose() => ObserveDuration();
+
+    public TimeSpan ObserveDuration()
+    {
+        var duration = _stopwatch.GetElapsedTime();
+
+        _observeDurationAction.Invoke(duration.TotalSeconds);
+
+        return duration;
+    }
+}
+
+public interface ITimer : IDisposable
+{
+    /// <summary>
+    /// Observes the duration and returns the observed value.
+    /// </summary>
+    TimeSpan ObserveDuration();
+}

--- a/src/Pilgaard.CronJobs/Telemetry/Timer.cs
+++ b/src/Pilgaard.CronJobs/Telemetry/Timer.cs
@@ -7,9 +7,9 @@ internal sealed class Timer : ITimer
 {
     private readonly ValueStopwatch _stopwatch = ValueStopwatch.StartNew();
     private readonly Action<double> _observeDurationAction;
-    internal Timer(Histogram<double> histogram)
+    internal Timer(Histogram<double> histogram, params KeyValuePair<string, object?>[] tags)
     {
-        _observeDurationAction = histogram.Record;
+        _observeDurationAction = duration => histogram.Record(duration, tags);
     }
 
     public void Dispose() => ObserveDuration();

--- a/src/Pilgaard.CronJobs/Telemetry/ValueStopwatch.cs
+++ b/src/Pilgaard.CronJobs/Telemetry/ValueStopwatch.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace Pilgaard.CronJobs.Telemetry;
+
+// Copied from: https://github.com/dotnet/extensions/blob/master/src/Shared/src/ValueStopwatch/ValueStopwatch.cs
+internal readonly struct ValueStopwatch
+{
+    private static readonly double _timestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+    private readonly long _startTimestamp;
+
+    public bool IsActive => _startTimestamp != 0;
+
+    private ValueStopwatch(long startTimestamp)
+    {
+        _startTimestamp = startTimestamp;
+    }
+
+    public static ValueStopwatch StartNew() => new(Stopwatch.GetTimestamp());
+
+    public TimeSpan GetElapsedTime()
+    {
+        // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+        // So it being 0 is a clear indication of default(ValueStopwatch)
+        if (!IsActive)
+        {
+            throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+        }
+
+        long end = Stopwatch.GetTimestamp();
+        long timestampDelta = end - _startTimestamp;
+        long ticks = (long)(_timestampToTicks * timestampDelta);
+        return new TimeSpan(ticks);
+    }
+}


### PR DESCRIPTION
Execution of `ICronJob.ExecuteAsync` is now counted and its duration is meassured using `System.Diagnostics.Metrics.Histogram`, through these keys:
```
cronjob_executeasync_milliseconds_bucket
cronjob_executeasync_milliseconds_count
cronjob_executeasync_milliseconds_sum
```

I've added a sample project showing how to export the metrics to Console & Prometheus, using OpenTelemetry.